### PR TITLE
feat: Implement scanning GitHub repositories before installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ require("nvim-security-scanner").setup({
     "tests/"
   },
   
+  -- GitHubリポジトリクローン後にディレクトリを保持
+  keep_cloned_repos = false,
+  
   -- プラグインマネージャー統合
   integrations = {
     lazy = true,
@@ -79,7 +82,8 @@ require("nvim-security-scanner").setup({
 ### コマンド
 
 - `:SecurityScanAll` - 全プラグインをスキャン
-- `:SecurityScan <plugin-name>` - 特定のプラグインをスキャン
+- `:SecurityScan <plugin-name>` - インストール済みの特定のプラグインをスキャン
+- `:SecurityScan <user/repo>` - GitHub リポジトリをクローンしてスキャン（例: `:SecurityScan neovim/nvim-lspconfig`）
 - `:SecurityReport` - 最新のスキャンレポートを表示
 
 ### プラグイン更新時の動作

--- a/lua/nvim-security-scanner/report.lua
+++ b/lua/nvim-security-scanner/report.lua
@@ -104,7 +104,29 @@ function M.generate_report_content()
   local findings = M.last_report.findings
   
   -- タイトルとサマリー
-  table.insert(lines, "# セキュリティスキャンレポート: " .. M.last_report.plugin_name)
+  local title = "# セキュリティスキャンレポート: " .. M.last_report.plugin_name
+  
+  -- GitHub リポジトリかどうかを確認
+  local is_github = M.last_report.plugin_name:match("^GitHub:")
+  if is_github then
+    local repo_name = M.last_report.plugin_name:gsub("^GitHub:", "")
+    title = "# セキュリティスキャンレポート: " .. repo_name .. " (GitHub)"
+    
+    -- リポジトリへのリンクを追加
+    table.insert(lines, title)
+    table.insert(lines, "")
+    
+    -- GitHubユーザー名を抽出
+    local github_user = repo_name
+    if findings[1] and findings[1].github_repo then
+      github_user = findings[1].github_repo
+    end
+    
+    table.insert(lines, "リポジトリ: https://github.com/" .. github_user)
+  else
+    table.insert(lines, title)
+  end
+  
   table.insert(lines, "")
   
   -- タイムスタンプ

--- a/test/github_scan_test.lua
+++ b/test/github_scan_test.lua
@@ -1,0 +1,120 @@
+-- GitHub リポジトリスキャン機能のテストスクリプト
+-- Neovimで以下のコマンドで実行:
+-- nvim --headless -u NONE -c "lua dofile('test/github_scan_test.lua')" -c "messages" -c "q"
+
+-- ルートへのパスを取得
+local root_dir = vim.fn.getcwd()
+
+-- プラグインのruntimepathを追加
+vim.opt.runtimepath:append(root_dir)
+
+-- モックアラート
+local notifications = {}
+local mock_notify = function(msg, level)
+  print("[通知] " .. msg)
+  table.insert(notifications, { message = msg, level = level })
+end
+vim.notify = mock_notify
+
+-- 便利な出力関数
+local function print_header(text)
+  print("\n" .. string.rep("=", 80))
+  print("== " .. text)
+  print(string.rep("=", 80) .. "\n")
+end
+
+local function print_success(text)
+  print("[成功] " .. text)
+end
+
+local function print_error(text)
+  print("[エラー] " .. text)
+end
+
+local function print_info(text)
+  print("[情報] " .. text)
+end
+
+-- プラグインを初期化
+local security_scanner = require("nvim-security-scanner")
+security_scanner.setup({
+  risk_threshold = "low",
+  scan_on_startup = false,
+  require_confirmation = false,
+  keep_cloned_repos = true -- テスト用に保持
+})
+
+-- スキャナーモジュールを取得
+local scanner = require("nvim-security-scanner.scanner")
+local report = require("nvim-security-scanner.report")
+
+-- GitHubリポジトリをスキャン
+print_header("GitHub リポジトリスキャンテスト")
+
+-- テスト用に小さいリポジトリを選択
+local test_repo = "neovim/nvim-lspconfig"
+print_info("テスト対象リポジトリ: " .. test_repo)
+
+-- リポジトリをスキャン
+print_info("リポジトリスキャン開始...")
+local time_start = os.time()
+local findings = scanner.scan_github_repo(test_repo)
+local time_end = os.time()
+local elapsed = time_end - time_start
+
+print_info("スキャン完了! 所要時間: " .. elapsed .. "秒")
+print_info("検出されたリスク: " .. #findings .. "件")
+
+-- レポートをテスト
+print_header("レポート表示テスト")
+
+-- オリジナルの関数を保存
+local original_show = report.show_last_report
+
+-- テスト用にモック
+report.show_last_report = function()
+  print_info("レポート表示呼び出し...")
+  
+  if not report.M or not report.M.last_report then
+    print_error("レポートが存在しません")
+    return
+  end
+  
+  print_success("レポートが存在します:")
+  print_info("プラグイン名: " .. report.M.last_report.plugin_name)
+  print_info("検出数: " .. #report.M.last_report.findings)
+  
+  -- レポート内容を取得
+  local content = report.generate_report_content()
+  print_info("レポート内容: " .. #content .. "行")
+  
+  -- サンプルとして先頭10行を表示
+  print_info("レポート内容（一部）:")
+  for i = 1, math.min(10, #content) do
+    print("  " .. content[i])
+  end
+end
+
+-- レポート表示
+report.show_last_report()
+
+-- テスト後のクリーンアップ
+print_header("テスト後のクリーンアップ")
+
+-- テスト用にクローンしたディレクトリを確認
+local tmp_dir = vim.fn.stdpath("cache") .. "/security_scanner/" .. test_repo:gsub("/", "_")
+if vim.fn.isdirectory(tmp_dir) == 1 then
+  print_info("テスト用クローンディレクトリ: " .. tmp_dir)
+  print_info("keep_cloned_repos が有効なため、ディレクトリは保持されています")
+  
+  -- テスト用に手動削除
+  if vim.fn.confirm("このディレクトリを削除しますか？", "&Yes\n&No", 2) == 1 then
+    vim.fn.delete(tmp_dir, "rf")
+    print_success("ディレクトリを削除しました")
+  else
+    print_info("ディレクトリを保持します")
+  end
+end
+
+print_header("テスト完了")
+print_success("GitHub リポジトリスキャン機能のテストが完了しました")


### PR DESCRIPTION
## Summary
- **機能追加**: インストール前のGitHubリポジトリをスキャンする機能の実装 (Issue #14)
- GitHub リポジトリを一時的にクローンして内容をスキャンする機能を追加
- `:SecurityScan user/repo` 形式のコマンドをサポート

## 機能詳細
- **GitHub リポジトリスキャン**:
  - `user/repo` 形式の引数を認識し、自動的にGitHubリポジトリとして解釈
  - リポジトリを一時ディレクトリにクローンしてスキャン
  - スキャン完了後にレポート生成
  - オプションによりクローンしたディレクトリを保持可能

- **設定オプション**:
  - `keep_cloned_repos` オプションでクローンしたリポジトリを保持するかどうかを設定

- **レポート改善**:
  - GitHub リポジトリからのスキャンを識別
  - リポジトリURLとの連携

## 動作確認方法
1. `:SecurityScan neovim/nvim-lspconfig` のようにGitHubリポジトリを指定
2. クローン後、自動的にスキャンが実行される
3. `:SecurityReport` で結果を確認

## テスト方法
テスト用スクリプトを用意:
```bash
nvim --headless -u NONE -c "lua dofile('test/github_scan_test.lua')" -c "messages" -c "q"
```

## 関連Issue
Closes #14

🤖 Generated with [Claude Code](https://claude.ai/code)